### PR TITLE
Fix:  docker-compose.yaml  volumes error path

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       TZ: Asia/Shanghai
       WAIT_HOSTS: mysql:3306
     volumes:
-      - ./server/config.yml:/mayfly/config.yml
+      - ./server/config.yml:/mayfly-go/config.yml
     depends_on:
       - mysql
     restart: always


### PR DESCRIPTION
go-server |2025/09/02 08:31:11 WARN 读取配置文件[/mayfly-go/config.yml]失败: read /mayfly-go/config.yml: is a directory, 使用系统默认配置或环境变量配置
go-server |2025/09/02 08:31:11 WARN 未配置log.level, 默认值: info
go-server |2025-09-02 08:31:11.136 [WARN] : 未配置jwt.key, 随机生成key为: T7dn47